### PR TITLE
Fix singleton multi translation units problem

### DIFF
--- a/include/language-manager/IG2pManager.h
+++ b/include/language-manager/IG2pManager.h
@@ -14,12 +14,17 @@ namespace LangMgr
 
     class IG2pManagerPrivate;
 
-    class LANG_MANAGER_EXPORT IG2pManager final : public QObject, public Singleton<IG2pManager> {
+    class LANG_MANAGER_EXPORT IG2pManager final : public QObject {
         Q_OBJECT
         Q_DECLARE_PRIVATE(IG2pManager)
     public:
         explicit IG2pManager(QObject *parent = nullptr);
         ~IG2pManager() override;
+
+        IG2pManager(const IG2pManager &) = delete;
+        IG2pManager &operator=(const IG2pManager &) = delete;
+
+        static IG2pManager *instance();
 
         bool initialize(const QString &pinyinDictPath, QString &errMsg);
         bool initialized();

--- a/include/language-manager/ILanguageManager.h
+++ b/include/language-manager/ILanguageManager.h
@@ -11,14 +11,18 @@ namespace LangMgr {
 
     class ILanguageManagerPrivate;
 
-    class LANG_MANAGER_EXPORT ILanguageManager final : public QObject,
-                                                       public Singleton<ILanguageManager> {
+    class LANG_MANAGER_EXPORT ILanguageManager final : public QObject {
         Q_OBJECT
         Q_DECLARE_PRIVATE(ILanguageManager)
 
     public:
         explicit ILanguageManager(QObject *parent = nullptr);
         ~ILanguageManager() override;
+
+        ILanguageManager(const ILanguageManager &) = delete;
+        ILanguageManager &operator=(const ILanguageManager &) = delete;
+
+        static ILanguageManager *instance();
 
         bool initialize(QString &errMsg);
         bool initialized();

--- a/src/G2pMgr/IG2pManager.cpp
+++ b/src/G2pMgr/IG2pManager.cpp
@@ -103,6 +103,11 @@ namespace LangMgr
         addG2p(new Unknown());
     }
 
+    IG2pManager *IG2pManager::instance() {
+        static IG2pManager obj;
+        return &obj;
+    }
+
     bool IG2pManager::initialize(const QString &pinyinDictPath, QString &errMsg) {
         Q_D(IG2pManager);
         Pinyin::setDictionaryPath(pinyinDictPath.toUtf8().toStdString());

--- a/src/LangMgr/ILanguageManager.cpp
+++ b/src/LangMgr/ILanguageManager.cpp
@@ -168,6 +168,11 @@ namespace LangMgr
 
     ILanguageManager::~ILanguageManager() = default;
 
+    ILanguageManager *ILanguageManager::instance() {
+        static ILanguageManager obj;
+        return &obj;
+    }
+
     bool ILanguageManager::initialize(QString &errMsg) {
         Q_D(ILanguageManager);
         for (const auto &factory : d->languages) {


### PR DESCRIPTION
Currently the singleton static instance is defined in headers. It may lead to the creation of multiple instances of the singleton if the header file is included in multiple translation units. Defining the static instance in source files (`.cpp`) solves the problem.